### PR TITLE
docs: add TweetClaw X workflow companion

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Keep this plugin responsible for AgentGate human chat, WebSocket delivery, chann
 openclaw plugins install @xquik/tweetclaw
 ```
 
-[TweetClaw](https://github.com/Xquik-dev/tweetclaw) covers scrape tweets, tweet scraper workflows, search tweets, search tweet replies, follower export, user lookup, media upload, media download, direct messages, monitor tweets, webhooks, giveaway draws, and approval-gated post tweets or post tweet replies. See the [ClawHub listing](https://clawhub.ai/plugins/@xquik/tweetclaw) or [npm package](https://www.npmjs.com/package/@xquik/tweetclaw) for setup details. Keep AgentGate credentials and X/Twitter credentials separate, and review visible X/Twitter actions through OpenClaw approval flows.
+[TweetClaw](https://github.com/Xquik-dev/tweetclaw) covers scrape tweets, tweet scraper workflows, search tweets, search tweet replies, follower export, user lookup, media upload, media download, direct messages, monitor tweets, webhooks, giveaway draws, and approval-gated post tweets or post tweet replies. Use the TweetClaw GitHub repo and [npm package](https://www.npmjs.com/package/@xquik/tweetclaw) for setup details; the [ClawHub discovery page](https://clawhub.ai/plugins/@xquik/tweetclaw) remains useful for browsing while that listing lags behind npm. Keep AgentGate credentials and X/Twitter credentials separate, and review visible X/Twitter actions through OpenClaw approval flows.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,16 @@ If the WebSocket disconnects, AgentGate queues channel messages (up to 100) unti
 
 Use `message` only for conversational chat that should run through the normal channel reply flow. Use `wake` for notifications, broadcasts, queue updates, and other system events. Use `agent` when AgentGate wants OpenClaw to run a separate explicit task.
 
+## Related X/Twitter Workflows
+
+Keep this plugin responsible for AgentGate human chat, WebSocket delivery, channel events, wake events, isolated agent turns, and AgentGate bearer-token routing. If the same OpenClaw agent also needs public X/Twitter data or visible X/Twitter actions, install TweetClaw as a separate OpenClaw plugin:
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+```
+
+[TweetClaw](https://github.com/Xquik-dev/tweetclaw) covers scrape tweets, tweet scraper workflows, search tweets, search tweet replies, follower export, user lookup, media upload, media download, direct messages, monitor tweets, webhooks, giveaway draws, and approval-gated post tweets or post tweet replies. See the [ClawHub listing](https://clawhub.ai/plugins/@xquik/tweetclaw) or [npm package](https://www.npmjs.com/package/@xquik/tweetclaw) for setup details. Keep AgentGate credentials and X/Twitter credentials separate, and review visible X/Twitter actions through OpenClaw approval flows.
+
 ## Development
 
 ```bash


### PR DESCRIPTION
## Summary

- Add a related X/Twitter workflow section for OpenClaw users who pair AgentGate human chat with TweetClaw.
- Keep this plugin scoped to AgentGate human chat, WebSocket delivery, channel events, wake events, isolated agent turns, and AgentGate bearer-token routing.
- Point public X/Twitter workflows to the separate TweetClaw OpenClaw plugin, with GitHub, npm, ClawHub discovery page, and install command links.
- Clarify that TweetClaw setup should use the GitHub repo and npm package while the ClawHub page remains useful for browsing as its listing lags npm.

## Validation

- `git diff --check`
- README link check: no broken links; `https://agentgate.example.com` classified as a documented placeholder
- `npm view @xquik/tweetclaw version openclaw.install --json` confirmed npmSpec `@xquik/tweetclaw@1.6.31`, defaultChoice `npm`, and minHostVersion `>=2026.5.4`
- `npm view agentgate-channel version --json` returned 404, matching the README's local-development install note while the package is unpublished
- `npm ci --ignore-scripts --no-audit --no-fund`
- `npm run build`
- `npm run test`
- `npm run lint` exits 0 with existing `@typescript-eslint/no-explicit-any` warnings
- `npm pack --dry-run --json`

Duplicate checks before opening:

- Repo code search and open/closed PR and issue searches for `TweetClaw`, `tweetclaw`, `@xquik/tweetclaw`, `Xquik-dev/tweetclaw`, the TweetClaw GitHub URL, npm package URL, and canonical ClawHub URL found no matches.
